### PR TITLE
Verbatim code fences

### DIFF
--- a/example_standalone/content/index.md
+++ b/example_standalone/content/index.md
@@ -10,6 +10,22 @@ test_string: this is a test string
 
 # {{ h1 }}
 
+```html
+<!-- templates/home.html -->
+{% extends 'base.html' %}
+```
+
+```javascript
+function App() {
+  return (
+    <div style={{padding: "16px"}}>
+      ...
+    </div>
+  );
+}
+```
+
+
 This is a test
 
 _ok_

--- a/tests/renderer/test_render_markdown.py
+++ b/tests/renderer/test_render_markdown.py
@@ -1,6 +1,4 @@
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
 from unittest.mock import patch
 
 from coltrane.renderer import StaticRequest, render_markdown
@@ -33,15 +31,7 @@ test data
     assert actual_context.get("template") == expected_template
 
 
-@dataclass
-class MarkdownContent:
-    metadata: Dict
-
-    def __str__(self):
-        return "test-content"
-
-
-@patch("coltrane.renderer.markdown_path", return_value=MarkdownContent(metadata=None))
+@patch("coltrane.renderer.render_markdown_path", return_value=("test-content", {}))
 def test_render_markdown_metadata(settings, tmp_path: Path):
     static_request = StaticRequest(path="/")
 

--- a/tests/renderer/test_render_markdown_text.py
+++ b/tests/renderer/test_render_markdown_text.py
@@ -8,6 +8,113 @@ title: My test markdown title
     
 # {{ title }}
 """
-    content, metadata = render_markdown_text(markdown_content)
+    (content, metadata) = render_markdown_text(markdown_content)
+    expected = '<h1 id="title">{{ title }}</h1>'
+
     assert metadata.get("title") == "My test markdown title"
-    assert content.strip() == '<h1 id="title">{{ title }}</h1>'
+    assert content.strip() == expected
+
+
+def test_render_markdown_text_with_code_fence():
+    markdown_content = """---
+title: My test markdown title
+---
+
+# {{ title }}
+
+```
+this is a lot of code
+```
+"""
+
+    (content, metadata) = render_markdown_text(markdown_content)
+    expected = """<h1 id="title">{{ title }}</h1>
+
+{% verbatim %}
+<pre><code>this is a lot of code
+</code></pre>
+{% endverbatim %}
+"""
+
+    assert metadata.get("title") == "My test markdown title"
+    assert content == expected
+
+
+def test_render_markdown_text_with_code_fence_with_language():
+    markdown_content = """---
+title: My test markdown title
+---
+
+# {{ title }}
+
+```python
+def blob():
+    pass
+```
+"""
+
+    (content, metadata) = render_markdown_text(markdown_content)
+    expected = """<h1 id="title">{{ title }}</h1>
+
+{% verbatim %}
+<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">blob</span><span class="p">():</span>
+    <span class="k">pass</span>
+</code></pre></div>
+{% endverbatim %}
+"""
+
+    assert metadata.get("title") == "My test markdown title"
+    assert content == expected
+
+
+def test_render_markdown_text_with_code_fence_react():
+    markdown_content = """---
+title: My test markdown title
+---
+
+# {{ title }}
+
+```javascript
+function App() {
+  return (
+    <div style={{padding: "16px"}}></div>
+  );
+}
+```
+"""
+
+    (content, metadata) = render_markdown_text(markdown_content)
+    expected = """<h1 id="title">{{ title }}</h1>
+
+{% verbatim %}
+<div class="codehilite"><pre><span></span><code><span class="kd">function</span><span class="w"> </span><span class="nx">App</span><span class="p">()</span><span class="w"> </span><span class="p">{</span><span class="w"></span>
+<span class="w">  </span><span class="k">return</span><span class="w"> </span><span class="p">(</span><span class="w"></span>
+<span class="w">    </span><span class="o">&lt;</span><span class="nx">div</span><span class="w"> </span><span class="nx">style</span><span class="o">=</span><span class="p">{{</span><span class="nx">padding</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;16px&quot;</span><span class="p">}}</span><span class="o">&gt;&lt;</span><span class="err">/div&gt;</span><span class="w"></span>
+<span class="w">  </span><span class="p">);</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</code></pre></div>
+{% endverbatim %}
+"""
+
+    assert metadata.get("title") == "My test markdown title"
+    assert content == expected
+
+
+def test_render_markdown_text_with_back_ticks():
+    markdown_content = """---
+title: My test markdown title
+---
+    
+# {{ title }}
+
+`this is code`
+"""
+
+    (content, metadata) = render_markdown_text(markdown_content)
+    expected = """<h1 id="title">{{ title }}</h1>
+
+<p><code>this is code</code></p>
+"""
+
+    assert metadata.get("title") == "My test markdown title"
+    assert content == expected


### PR DESCRIPTION
Add support `{% verbatim %}` templatetags around code fences (i.e. three back-ticks) to handle #46.