### PR TITLE
Give priority to user custom apps

### DIFF
--- a/src/coltrane/__init__.py
+++ b/src/coltrane/__init__.py
@@ -96,7 +96,7 @@ def _merge_installed_apps(django_settings: dict[str, Any], installed_apps: list[
     """
 
     if "INSTALLED_APPS" in django_settings:
-        installed_apps.extend(list(django_settings["INSTALLED_APPS"]))
+        installed_apps = list(django_settings["INSTALLED_APPS"]) + installed_apps
 
         # Remove INSTALLED_APPS from django_settings since it overrides the default settings
         # that gets merged later


### PR DESCRIPTION
I have a custom app in my coltrane site that override the build command, placing the user custom apps at the beginning of the installed apps list allow them to take priority over default apps